### PR TITLE
Add the UTF charset

### DIFF
--- a/src/main/java/com/kongz/graylog/plugins/slack/SlackClient.java
+++ b/src/main/java/com/kongz/graylog/plugins/slack/SlackClient.java
@@ -62,7 +62,7 @@ public class SlackClient {
       }
       conn.setDoOutput(true);
       conn.setRequestMethod("POST");
-      conn.setRequestProperty("Content-Type", "application/json");
+      conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
       if (!isNullOrEmpty(slackToken)) {
         conn.setRequestProperty("Authorization", "Bearer " + slackToken);
       }


### PR DESCRIPTION
The new Slack API requires charset on Content-Type header